### PR TITLE
Remove .png, .sav & .txt from banned suffixes.

### DIFF
--- a/parse_pack.py
+++ b/parse_pack.py
@@ -93,8 +93,8 @@ def parse_folder(target_folder, output_file):
                        ".bak", ".bat", ".bsa", ".bps",
                        ".bst", ".c", ".cht", ".dat", ".db", ".docx",
                        ".exe", ".ips", ".jpg", ".json", ".mso",
-                       ".ods", ".odt", ".pc", ".pdf", ".png", ".sav", ".srm",
-                       ".sto", ".txt", ".tmp", ".xdelta", ".xls",
+                       ".ods", ".odt", ".pc", ".pdf", ".srm",
+                       ".sto", ".tmp", ".xdelta", ".xls",
                        "/os.pce", "/thumbs.db", "/menu.bin", "/desktop.ini",
                        "/.ds_store")  # must be lowercase
 


### PR DESCRIPTION
These suffixes are currently in use by multiple packs:

* `.png` is used by the MiSTer pack 
* `.txt` is used by the MiSTer pack and the MSX add-on
* `.sav` is used by MiSTer, both Nt Mini packs, and NES 2.0 because of Kid Dracula